### PR TITLE
This is not yet a pull request: Backport the codebase to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ option(RPCLIB_MSVC_STATIC_RUNTIME "MSVC only: build with /MT instead of /MD" OFF
 #
 ################################################################################
 
+set(RPCLIB_CXX_STANDARD 11)
+
+set(CMAKE_CXX_STANDARD ${RPCLIB_CXX_STANDARD})
+add_definitions(-DRPCLIB_CXX_STANDARD=${RPCLIB_CXX_STANDARD})
+
 include(TargetArch)
 
 set(RPCLIB_VERSION_MAJOR 1)
@@ -75,7 +80,7 @@ function(set_rpclib_flags TARGET)
         set(RPCLIB_BUILD_FLAGS
             "-Wall -pedantic -Weverything -Wno-c++98-compat\
             -Wno-c++98-compat-pedantic -Wno-padded -Wno-missing-prototypes\
-            -pthread -std=c++14 -stdlib=libc++")
+            -pthread -stdlib=libc++")
 
         set_target_properties(${TARGET}
                 PROPERTIES
@@ -95,7 +100,7 @@ function(set_rpclib_flags TARGET)
 
     elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
 
-        set(RPCLIB_BUILD_FLAGS "-Wall -pedantic -pthread -std=c++14")
+        set(RPCLIB_BUILD_FLAGS "-Wall -pedantic -pthread")
 
         if(RPCLIB_ENABLE_COVERAGE)
             set(RPCLIB_BUILD_FLAGS "${RPCLIB_BUILD_FLAGS} -g --coverage -O0")

--- a/include/rpc/compat.hpp
+++ b/include/rpc/compat.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#ifndef RPCLIB_COMPAT_HPP
+#define RPCLIB_COMPAT_HPP
+
+namespace std {
+
+#if RPCLIB_CXX_STANDARD < 14
+template<typename T, typename... Ts>
+unique_ptr<T> make_unique(Ts&&... params)
+{
+    return std::unique_ptr<T>(new T(std::forward<Ts>(params)...));
+}
+#endif
+
+}
+
+#endif /* end of include guard: RPCLIB_COMPAT_HPP */

--- a/include/rpc/detail/call.h
+++ b/include/rpc/detail/call.h
@@ -11,24 +11,90 @@
 namespace rpc {
 namespace detail {
 
+
+//! \brief Calls a functor with argument provided directly
+template <typename Functor, typename Arg>
+auto call(Functor f, Arg &&arg)
+    -> decltype(f(std::forward<Arg>(arg))) {
+    return f(std::forward<Arg>(arg));
+}
+
+#if RPCLIB_CXX_STANDARD == 14
 template <typename Functor, typename... Args, std::size_t... I>
-decltype(auto) call_helper(Functor func, std::tuple<Args...> &&params,
-                           std::index_sequence<I...>) {
+auto call_helper(Functor func, std::tuple<Args...> &&params,
+        std::index_sequence<I...>)
+    -> decltype(func(std::get<I>(params)...)) {
     return func(std::get<I>(params)...);
 }
 
 //! \brief Calls a functor with arguments provided as a tuple
-
-template <typename Functor, typename Arg>
-decltype(auto) call(Functor f, Arg &&arg) {
-    return f(std::forward<Arg>(arg));
-}
-
 template <typename Functor, typename... Args>
-decltype(auto) call(Functor f, std::tuple<Args...> &args) {
+auto call(Functor f, std::tuple<Args...> &args)
+    -> decltype(call_helper(f, std::forward<std::tuple<Args...>>(args), std::index_sequence_for<Args...>{})) {
     return call_helper(f, std::forward<std::tuple<Args...>>(args),
                        std::index_sequence_for<Args...>{});
 }
+
+#elif RPCLIB_CXX_STANDARD == 11
+
+// We're limited to 5 arguments per call
+template <typename Functor, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4>
+auto call(Functor f, std::tuple<Arg0, Arg1, Arg2, Arg3, Arg4> &args)
+    -> decltype(f(std::get<0>(args), std::get<1>(args), std::get<2>(args), std::get<3>(args), std::get<4>(args)))
+{
+    return f(
+            std::get<0>(args),
+            std::get<1>(args),
+            std::get<2>(args),
+            std::get<3>(args),
+            std::get<4>(args)
+    );
+}
+
+template <typename Functor, typename Arg0, typename Arg1, typename Arg2, typename Arg3>
+auto call(Functor f, std::tuple<Arg0, Arg1, Arg2, Arg3> &args)
+    -> decltype(f(std::get<0>(args), std::get<1>(args), std::get<2>(args), std::get<3>(args)))
+{
+    return f(
+            std::get<0>(args),
+            std::get<1>(args),
+            std::get<2>(args),
+            std::get<3>(args)
+    );
+}
+
+template <typename Functor, typename Arg0, typename Arg1, typename Arg2>
+auto call(Functor f, std::tuple<Arg0, Arg1, Arg2> &args)
+    -> decltype(f(std::get<0>(args), std::get<1>(args), std::get<2>(args)))
+{
+    return f(
+            std::get<0>(args),
+            std::get<1>(args),
+            std::get<2>(args)
+    );
+}
+
+template <typename Functor, typename Arg0, typename Arg1>
+auto call(Functor f, std::tuple<Arg0, Arg1> &args)
+    -> decltype(f(std::get<0>(args), std::get<1>(args)))
+{
+    return f(
+            std::get<0>(args),
+            std::get<1>(args)
+    );
+}
+
+template <typename Functor, typename Arg0>
+auto call(Functor f, std::tuple<Arg0> &args)
+    -> decltype(f(std::get<0>(args)))
+{
+    return f(
+            std::get<0>(args)
+    );
+}
+
+#endif
+
 }
 }
 

--- a/include/rpc/detail/func_traits.h
+++ b/include/rpc/detail/func_traits.h
@@ -45,7 +45,7 @@ struct func_traits<R (C::*)(Args...) const> : func_traits<R (*)(Args...)> {};
 template <typename R, typename... Args> struct func_traits<R (*)(Args...)> {
     using result_type = R;
     using arg_count = std::integral_constant<std::size_t, sizeof...(Args)>;
-    using args_type = std::tuple<std::decay_t<Args>...>;
+    using args_type = std::tuple<typename std::decay<Args>::type...>;
 };
 
 template <typename T>

--- a/include/rpc/detail/make_unique.h
+++ b/include/rpc/detail/make_unique.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifndef MAKE_UNIQUE_H_FOOBAR
+#define MAKE_UNIQUE_H_FOOBAR
+
+#include <memory>
+
+namespace rpc {
+namespace detail {
+
+#if RPCLIB_CXX_STANDARD >= 14
+
+using std::unique_ptr:
+
+#else
+template<typename T, typename... Ts>
+std::unique_ptr<T> make_unique(Ts&&... params)
+{
+    return std::unique_ptr<T>(new T(std::forward<Ts>(params)...));
+}
+#endif
+
+} /* detail */
+} /* rpc  */
+
+#endif /* end of include guard: MAKE_UNIQUE_H_FOOBAR */
+

--- a/include/rpc/detail/response.h
+++ b/include/rpc/detail/response.h
@@ -5,6 +5,7 @@
 
 #include "rpc/detail/log.h"
 #include "rpc/msgpack.hpp"
+#include "rpc/detail/make_unique.h"
 
 namespace rpc {
 namespace detail {
@@ -83,7 +84,7 @@ private:
 
 template <typename T>
 inline response response::make_result(uint32_t id, T &&result) {
-    auto z = std::make_unique<RPCLIB_MSGPACK::zone>();
+    auto z = rpc::detail::make_unique<RPCLIB_MSGPACK::zone>();
     RPCLIB_MSGPACK::object o(std::forward<T>(result), *z);
     response inst;
     inst.id_ = id;
@@ -102,7 +103,7 @@ response::make_result(uint32_t id, std::unique_ptr<RPCLIB_MSGPACK::object_handle
 
 template <typename T>
 inline response response::make_error(uint32_t id, T &&error) {
-    auto z = std::make_unique<RPCLIB_MSGPACK::zone>();
+    auto z = rpc::detail::make_unique<RPCLIB_MSGPACK::zone>();
     RPCLIB_MSGPACK::object o(std::forward<T>(error), *z);
     response inst;
     inst.id_ = id;

--- a/include/rpc/detail/util.h
+++ b/include/rpc/detail/util.h
@@ -4,11 +4,12 @@
 #define UTIL_H_YRIZ63UJ
 
 #include "rpc/msgpack.hpp"
+#include "rpc/detail/make_unique.h"
 
 namespace rpc {
 namespace detail {
 template <typename T> RPCLIB_MSGPACK::object_handle pack(T &&o) {
-    auto z = std::make_unique<RPCLIB_MSGPACK::zone>();
+    auto z = rpc::detail::make_unique<RPCLIB_MSGPACK::zone>();
     RPCLIB_MSGPACK::object obj(std::forward<T>(o), *z);
     return RPCLIB_MSGPACK::object_handle(obj, std::move(z));
 }

--- a/include/rpc/dispatcher.h
+++ b/include/rpc/dispatcher.h
@@ -16,6 +16,7 @@
 #include "rpc/detail/log.h"
 #include "rpc/detail/not.h"
 #include "rpc/detail/response.h"
+#include "rpc/detail/make_unique.h"
 
 namespace rpc {
 

--- a/include/rpc/dispatcher.inl
+++ b/include/rpc/dispatcher.inl
@@ -15,7 +15,7 @@ void dispatcher::bind(std::string const &name, F func,
         std::make_pair(name, [func, name](RPCLIB_MSGPACK::object const &args) {
             enforce_arg_count(name, 0, args.via.array.size);
             func();
-            return std::make_unique<RPCLIB_MSGPACK::object_handle>();
+            return rpc::detail::make_unique<RPCLIB_MSGPACK::object_handle>();
         }));
 }
 
@@ -32,8 +32,7 @@ void dispatcher::bind(std::string const &name, F func,
             enforce_arg_count(name, args_count, args.via.array.size);
             args_type args_real;
             args.convert(&args_real);
-            detail::call(func, args_real);
-            return std::make_unique<RPCLIB_MSGPACK::object_handle>();
+            return rpc::detail::make_unique<RPCLIB_MSGPACK::object_handle>();
         }));
 }
 
@@ -46,9 +45,9 @@ void dispatcher::bind(std::string const &name, F func,
     funcs_.insert(std::make_pair(name, [func,
                                         name](RPCLIB_MSGPACK::object const &args) {
         enforce_arg_count(name, 0, args.via.array.size);
-        auto z = std::make_unique<RPCLIB_MSGPACK::zone>();
+        auto z = rpc::detail::make_unique<RPCLIB_MSGPACK::zone>();
         auto result = RPCLIB_MSGPACK::object(func(), *z);
-        return std::make_unique<RPCLIB_MSGPACK::object_handle>(result, std::move(z));
+        return rpc::detail::make_unique<RPCLIB_MSGPACK::object_handle>(result, std::move(z));
     }));
 }
 
@@ -65,9 +64,9 @@ void dispatcher::bind(std::string const &name, F func,
         enforce_arg_count(name, args_count, args.via.array.size);
         args_type args_real;
         args.convert(&args_real);
-        auto z = std::make_unique<RPCLIB_MSGPACK::zone>();
+        auto z = rpc::detail::make_unique<RPCLIB_MSGPACK::zone>();
         auto result = RPCLIB_MSGPACK::object(detail::call(func, args_real), *z);
-        return std::make_unique<RPCLIB_MSGPACK::object_handle>(result, std::move(z));
+        return rpc::detail::make_unique<RPCLIB_MSGPACK::object_handle>(result, std::move(z));
     }));
 }
 }

--- a/lib/rpc/detail/server_session.cc
+++ b/lib/rpc/detail/server_session.cc
@@ -50,10 +50,8 @@ void server_session::do_read() {
                     output_buf_.clear();
 
                     // any worker thread can take this call
-                    io_->post([
-                        this, msg, z = std::shared_ptr<RPCLIB_MSGPACK::zone>(
-                                       result.zone().release())
-                    ]() {
+                    auto z = std::shared_ptr<RPCLIB_MSGPACK::zone>( result.zone().release());
+                    io_->post([this, msg, z]() {
                         this_handler().clear();
                         this_session().clear();
                         this_server().cancel_stop();

--- a/tests/rpc/client_test.cc
+++ b/tests/rpc/client_test.cc
@@ -7,7 +7,6 @@
 #include <chrono>
 
 using namespace rpc::testutils;
-using namespace std::literals::chrono_literals;
 
 class client_test : public testing::Test {
 public:
@@ -47,7 +46,7 @@ TEST_F(client_test, notification) {
     rpc::client client("127.0.0.1", test_port);
     client.send("dummy_void_zeroarg");
     client.wait_all_responses();
-    std::this_thread::sleep_for(50ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
 }
 
 TEST_F(client_test, large_return) {

--- a/tests/rpc/server_test.cc
+++ b/tests/rpc/server_test.cc
@@ -10,7 +10,6 @@
 #include "testutils.h"
 
 using namespace rpc::testutils;
-using namespace std::literals::chrono_literals;
 
 const int test_port = 8080;
 
@@ -19,11 +18,11 @@ public:
     server_workers_test()
         : s("127.0.0.1", test_port), long_count(0), short_count(0) {
         s.bind("long_func", [this]() {
-            std::this_thread::sleep_for(500ms);
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
             ++long_count;
         });
         s.bind("short_func", [this]() {
-            std::this_thread::sleep_for(100ms);
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
             ++short_count;
         });
     }

--- a/tests/rpc/this_handler_test.cc
+++ b/tests/rpc/this_handler_test.cc
@@ -79,21 +79,19 @@ TEST_F(this_handler_test, set_special_response) {
 }
 
 TEST_F(this_handler_test, disable_response) {
-    using namespace std::chrono_literals;
     s.bind("noresp", []() { rpc::this_handler().disable_response(); });
     s.async_run();
 
     rpc::client c("127.0.0.1", test_port);
     auto f = c.async_call("noresp");
-    EXPECT_EQ(f.wait_for(50ms), std::future_status::timeout);
+    EXPECT_EQ(f.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
 }
 
 TEST_F(this_handler_test, enable_response) {
-    using namespace std::chrono_literals;
     s.bind("noresp", []() { rpc::this_handler().disable_response(); });
     s.async_run();
 
     rpc::client c("127.0.0.1", test_port);
     auto f = c.async_call("noresp");
-    EXPECT_EQ(f.wait_for(50ms), std::future_status::timeout);
+    EXPECT_EQ(f.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
 }

--- a/tests/rpc/this_server_test.cc
+++ b/tests/rpc/this_server_test.cc
@@ -25,11 +25,10 @@ protected:
 };
 
 TEST_F(this_server_test, stop) {
-    using namespace std::chrono_literals;
     s.bind("stop_server", []() { rpc::this_server().stop(); });
     s.async_run();
     c1.call("stop_server");
-    std::this_thread::sleep_for(100ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     EXPECT_EQ(c1.get_connection_state(),
               client::connection_state::disconnected);

--- a/tests/rpc/this_session_test.cc
+++ b/tests/rpc/this_session_test.cc
@@ -23,20 +23,18 @@ protected:
 };
 
 TEST_F(this_session_test, post_exit) {
-    using namespace std::chrono_literals;
     s.bind("exit", []() { rpc::this_session().post_exit(); });
     s.async_run();
 
     rpc::client c("127.0.0.1", test_port);
     c.call("exit");
-    std::this_thread::sleep_for(100ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     auto f = c.async_call("exit");
-    EXPECT_EQ(f.wait_for(50ms), std::future_status::timeout);
+    EXPECT_EQ(f.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
     EXPECT_EQ(c.get_connection_state(), client::connection_state::disconnected);
 }
 
 TEST_F(this_session_test, post_exit_specific_to_session) {
-    using namespace std::chrono_literals;
     s.bind("exit", [](bool do_exit) {
         if (do_exit) {
             rpc::this_session().post_exit();
@@ -48,10 +46,10 @@ TEST_F(this_session_test, post_exit_specific_to_session) {
     rpc::client c2("127.0.0.1", test_port);
     c2.call("exit", false);
     c.call("exit", true);
-    std::this_thread::sleep_for(100ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     auto f = c.async_call("exit");
     c2.call("exit", false);
-    EXPECT_EQ(f.wait_for(50ms), std::future_status::timeout);
+    EXPECT_EQ(f.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
     EXPECT_EQ(c.get_connection_state(), client::connection_state::disconnected);
     EXPECT_EQ(c2.get_connection_state(), client::connection_state::connected);
 }


### PR DESCRIPTION
- Replaces chrono_literals with std::chrono::milliseconds()
- Define make_unique if not available
- Replace index_sequence with manual indexing of tuple elements
  (limits to 5 args per call on C++11)
- Replace decltype(auto) function types with C++11-compatible notation
- Replace named captures in lambdas with regular captures
- Replaced decay_t with decay<>::type