### PR TITLE
fix mandelbrot example

### DIFF
--- a/examples/mandelbrot/mandelbrot.h
+++ b/examples/mandelbrot/mandelbrot.h
@@ -3,7 +3,7 @@
 #ifndef MANDELBROT_H_I0UEF3KR
 #define MANDELBROT_H_I0UEF3KR
 
-#include "msgpack.hpp"
+#include "rpc/msgpack.hpp"
 #include <vector>
 
 struct pixel {


### PR DESCRIPTION
On Ubuntu 16.04 with `sudo apt install libsfml-dev` and `cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DRPCLIB_ENABLE_LOGGING=1 -DRPCLIB_BUILD_EXAMPLES=1`