### PR TITLE
Add pkg-config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,12 +333,11 @@ if(RPCLIB_BUILD_TESTS)
     # Set less strict warning for tests, since google test is not quite
     # warning-clean
     if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-        get_target_property(ORIGINAL_FLAGS ${TEST_PROJECT_NAME} COMPILE_FLAGS)
-        set_target_properties(${TEST_PROJECT_NAME} PROPERTIES COMPILE_FLAGS
-            "${ORIGINAL_FLAGS} -Wno-sign-conversion -Wno-weak-vtables -Wno-unused-member-function \
-            -Wno-global-constructors -Wno-used-but-marked-unused -Wno-covered-switch-default \
-            -Wno-missing-variable-declarations -Wno-deprecated -Wno-unused-macros -Wno-undef \
-            -Wno-exit-time-destructors -Wno-switch-enum -Wno-format-nonliteral -Wno-unused-parameter -Wno-disabled-macro-expansion")
+        get_target_property(ORIGINAL_FLAGS ${TEST_PROJECT_NAME} COMPILE_OPTION)
+        target_compile_options(${TEST_PROJECT_NAME} PRIVATE -Wno-sign-conversion -Wno-weak-vtables -Wno-unused-member-function
+            -Wno-global-constructors -Wno-used-but-marked-unused -Wno-covered-switch-default
+            -Wno-missing-variable-declarations -Wno-deprecated -Wno-unused-macros -Wno-undef
+            -Wno-exit-time-destructors -Wno-switch-enum -Wno-format-nonliteral -Wno-unused-parameter -Wno-disabled-macro-expansion)
     endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ function(set_rpclib_flags TARGET)
     # clang is the compiler used for developing mainly, so
     # this is where I set the highest warning level
     # but feel free to add similar flags to GCC
-    if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
         list(APPEND RPCLIB_BUILD_FLAGS
             -Wall -pedantic -Weverything -Wno-c++98-compat
@@ -111,7 +111,7 @@ function(set_rpclib_flags TARGET)
 
         set(RPCLIB_DEP_LIBRARIES "pthread")
 
-    elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
         list(APPEND RPCLIB_BUILD_FLAGS -Wall -pedantic -pthread)
         if(RPCLIB_CXX_STANDARD EQUAL 14)
@@ -134,7 +134,7 @@ function(set_rpclib_flags TARGET)
 
         set(RPCLIB_DEP_LIBRARIES "pthread")
 
-    elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
         set(RPCLIB_COMPILE_DEFINITIONS
             "${RPCLIB_COMPILE_DEFINITIONS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ function(set_rpclib_flags TARGET)
     # clang is the compiler used for developing mainly, so
     # this is where I set the highest warning level
     # but feel free to add similar flags to GCC
+    set(RPCLIB_BUILD_FLAGS "") # reset flags
+    
     if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
         list(APPEND RPCLIB_BUILD_FLAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,8 +185,8 @@ function(set_rpclib_flags TARGET)
 
     target_link_libraries(${TARGET} ${RPCLIB_DEP_LIBRARIES})
     target_include_directories(
-        ${TARGET} INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/rpc>
+        ${TARGET} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
     )
     target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,26 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/rpclibConfigVersion.cmake
   DESTINATION ${CONFIG_PACKAGE_LOCATION}
 )
+
+################################################################################
+#
+# Pkg-config
+#
+################################################################################
+if(NOT MSVC)  # Don't install pkg-config files when building with MSVC
+  # Variables for pkg-config files
+  set(prefix "${CMAKE_INSTALL_PREFIX}")
+  set(exec_prefix "")
+  set(libdir "${CMAKE_INSTALL_PREFIX}/lib")
+  set(includedir "${CMAKE_INSTALL_PREFIX}/include")
+  set(rpclib_version ${RPCLIB_VERSION_MAJOR}.${RPCLIB_VERSION_MINOR}.${RPCLIB_VERSION_PATCH})
+  get_target_property(rpclib_cflags ${OUTPUT_LIBRARY_NAME} COMPILE_OPTIONS)
+  string(REPLACE ";" " " rpclib_cflags "${rpclib_cflags}") # Convert list to string
+
+  configure_file(rpclib.pc.in "${CMAKE_CURRENT_BINARY_DIR}/rpclib.pc" @ONLY)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/rpclib.pc" DESTINATION "${libdir}/pkgconfig")
+endif()
+
 ################################################################################
 #
 # CPack

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,9 +185,9 @@ function(set_rpclib_flags TARGET)
 
     target_link_libraries(${TARGET} ${RPCLIB_DEP_LIBRARIES})
     target_include_directories(
-        ${TARGET}
-        PUBLIC include
-        PRIVATE include/rpc
+        ${TARGET} INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/rpc>
+        $<INSTALL_INTERFACE:include>
     )
     target_include_directories(
         ${TARGET} SYSTEM
@@ -285,7 +285,7 @@ if (RPCLIB_MSVC_STATIC_RUNTIME)
 
 endif()
 
-install(TARGETS ${OUTPUT_LIBRARY_NAME} DESTINATION lib)
+install(TARGETS ${OUTPUT_LIBRARY_NAME} DESTINATION lib EXPORT rpclibTargets)
 install(DIRECTORY include/
     DESTINATION include
     FILES_MATCHING
@@ -293,7 +293,6 @@ install(DIRECTORY include/
     PATTERN "*.hpp"
     PATTERN "*.inl"
     PATTERN "*.in" EXCLUDE)
-install(FILES ${PROJECT_SOURCE_DIR}/include/rpc/version.h DESTINATION include/rpc)
 
 if(RPCLIB_GENERATE_COMPDB)
     set(CMAKE_EXPORT_COMPILE_COMMANDS "ON") # for YCM
@@ -364,6 +363,43 @@ if(RPCLIB_BUILD_EXAMPLES)
 endif()
 
 
+################################################################################
+#
+# Cmake Package
+#
+################################################################################
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/rpclibConfigVersion.cmake"
+  VERSION ${RPCLIB_VERSION_MAJOR}.${RPCLIB_VERSION_MINOR}.${RPCLIB_VERSION_PATCH}
+  COMPATIBILITY AnyNewerVersion
+)
+
+set(CONFIG_PACKAGE_LOCATION lib/cmake/rpclib)
+set(INCLUDE_INSTALL_DIR include/ )
+
+configure_package_config_file(cmake/rpclibConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/rpclibConfig.cmake
+  INSTALL_DESTINATION ${CONFIG_PACKAGE_LOCATION}
+  PATH_VARS INCLUDE_INSTALL_DIR
+)
+
+export(EXPORT rpclibTargets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/rpclibTargets.cmake"
+  NAMESPACE rpclib::
+)
+
+install(EXPORT rpclibTargets
+  FILE rpclibTargets.cmake
+  NAMESPACE rpclib::
+  DESTINATION ${CONFIG_PACKAGE_LOCATION}
+)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/rpclibConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/rpclibConfigVersion.cmake
+  DESTINATION ${CONFIG_PACKAGE_LOCATION}
+)
 ################################################################################
 #
 # CPack

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,14 +86,15 @@ function(set_rpclib_flags TARGET)
     # but feel free to add similar flags to GCC
     if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
 
-        set(RPCLIB_BUILD_FLAGS
-            "-Wall -pedantic -Weverything -Wno-c++98-compat\
-            -Wno-c++98-compat-pedantic -Wno-padded -Wno-missing-prototypes\
-            -Wno-undef -pthread")
+        list(APPEND RPCLIB_BUILD_FLAGS
+            -Wall -pedantic -Weverything -Wno-c++98-compat
+            -Wno-c++98-compat-pedantic -Wno-padded -Wno-missing-prototypes
+            -Wno-undef -pthread)
+
         if(RPCLIB_CXX_STANDARD EQUAL 14)
-            set(RPCLIB_BUILD_FLAGS "${RPCLIB_BUILD_FLAGS} -std=c++14")
+            target_compile_options(${TARGET} PUBLIC -std=c++14)
         elseif(RPCLIB_CXX_STANDARD EQUAL 11)
-            set(RPCLIB_BUILD_FLAGS "${RPCLIB_BUILD_FLAGS} -std=c++11")
+            target_compile_options(${TARGET} PUBLIC -std=c++11)
         endif()
 
         if(RPCLIB_ENABLE_COVERAGE)
@@ -103,20 +104,20 @@ function(set_rpclib_flags TARGET)
         endif()
 
         if(RPCLIB_FORCE_M32)
-            set(RPCLIB_BUILD_FLAGS "${RPCLIB_BUILD_FLAGS} -m32")
+            list(APPEND RPCLIB_BUILD_FLAGS -m32)
         elseif(RPCLIB_FORCE_M64)
-            set(RPCLIB_BUILD_FLAGS "${RPCLIB_BUILD_FLAGS} -m64")
+            list(APPEND RPCLIB_BUILD_FLAGS -m64)
         endif()
 
         set(RPCLIB_DEP_LIBRARIES "pthread")
 
     elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
 
-        set(RPCLIB_BUILD_FLAGS "-Wall -pedantic -pthread")
+        list(APPEND RPCLIB_BUILD_FLAGS -Wall -pedantic -pthread)
         if(RPCLIB_CXX_STANDARD EQUAL 14)
-            set(RPCLIB_BUILD_FLAGS "${RPCLIB_BUILD_FLAGS} -std=c++14")
+            target_compile_options(${TARGET} PUBLIC -std=c++14)
         elseif(RPCLIB_CXX_STANDARD EQUAL 11)
-            set(RPCLIB_BUILD_FLAGS "${RPCLIB_BUILD_FLAGS} -std=c++11")
+            target_compile_options(${TARGET} PUBLIC -std=c++11)
         endif()
 
         if(RPCLIB_ENABLE_COVERAGE)
@@ -126,9 +127,9 @@ function(set_rpclib_flags TARGET)
         endif()
 
         if(RPCLIB_FORCE_M32)
-            set(RPCLIB_BUILD_FLAGS "${RPCLIB_BUILD_FLAGS} -m32")
+            list(APPEND RPCLIB_BUILD_FLAGS -m32)
         elseif(RPCLIB_FORCE_M64)
-            set(RPCLIB_BUILD_FLAGS "${RPCLIB_BUILD_FLAGS} -m64")
+            list(APPEND RPCLIB_BUILD_FLAGS -m64)
         endif()
 
         set(RPCLIB_DEP_LIBRARIES "pthread")
@@ -153,7 +154,7 @@ function(set_rpclib_flags TARGET)
     endif()
 
     if (RPCLIB_EXTRA_BUILD_FLAGS)
-        set(RPCLIB_BUILD_FLAGS "${RPCLIB_BUILD_FLAGS} ${RPCLIB_EXTRA_BUILD_FLAGS}")
+        list(APPEND RPCLIB_BUILD_FLAGS ${RPCLIB_EXTRA_BUILD_FLAGS})
     endif()
 
     set(RPCLIB_COMPILE_DEFINITIONS
@@ -172,9 +173,7 @@ function(set_rpclib_flags TARGET)
     endif()
 
     if(RPCLIB_BUILD_FLAGS)
-        set_target_properties(${TARGET}
-                PROPERTIES
-                COMPILE_FLAGS "${RPCLIB_BUILD_FLAGS}")
+        target_compile_options(${TARGET} PRIVATE ${RPCLIB_BUILD_FLAGS})
     endif()
 
     if(RPCLIB_COMPILE_DEFINITIONS)

--- a/cmake/rpclibConfig.cmake.in
+++ b/cmake/rpclibConfig.cmake.in
@@ -1,0 +1,10 @@
+# Example usage:
+#   find_package(rpclib REQUIRED)
+#   add_executable(foo main.cpp)
+#   target_link_libraries(foo rpclib::rpc)
+
+@PACKAGE_INIT@
+
+set(RPCLIB_VERSION @RPCLIB_VERSION_MAJOR@.@RPCLIB_VERSION_MINOR@.@RPCLIB_VERSION_PATCH@)
+
+include("${CMAKE_CURRENT_LIST_DIR}/rpclibTargets.cmake")

--- a/rpclib.pc.in
+++ b/rpclib.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: rpclib
+Description: rpclib is a msgpack-rpc library written using modern C++
+Version: @rpclib_version@
+Libs: -L${libdir} -l@OUTPUT_LIBRARY_NAME@
+Cflags: -I${includedir} @rpclib_cflags@

--- a/tests/testutils.h
+++ b/tests/testutils.h
@@ -4,7 +4,7 @@
 #define TESTUTILS_H_LHCAMVUX
 
 #include "gmock/gmock.h"
-#include "msgpack.hpp"
+#include "rpc/msgpack.hpp"
 #include <regex>
 #include <thread>
 #include <tuple>


### PR DESCRIPTION
Adds `pkg-config` support, which generates an `rpclib.pc` like : 
```
prefix=/usr/local
exec_prefix=
libdir=/usr/local/lib
includedir=/usr/local/include

Name: rpclib
Description: rpclib is a msgpack-rpc library written using modern C++
Version: 2.1.0
Libs: -L${libdir} -lrpc
Cflags: -I${includedir} -std=c++14 -Wall -pedantic -pthread
```
Files are installed in `${CMAKE_INSTALL_PREFIX}/lib/pkgconfig`

With Qt you can do something like : 
``` 
CONFIG += link_pkgconfig
PKGCONFIG += rpclib
``` 
Which adds the result of `pkg-config --cflags rpclib` to the compiler.