### PR TITLE
Added self to lambda capture lists to prevent this from being destroyed

### DIFF
--- a/lib/rpc/detail/server_session.cc
+++ b/lib/rpc/detail/server_session.cc
@@ -60,7 +60,7 @@ void server_session::do_read() {
                     // any worker thread can take this call
                     auto z = std::shared_ptr<RPCLIB_MSGPACK::zone>(
                         result.zone().release());
-                    io_->post([this, msg, z]() {
+                    io_->post([this, self, msg, z]() {
                         this_handler().clear();
                         this_session().clear();
                         this_session().set_id(reinterpret_cast<session_id_t>(this));
@@ -96,7 +96,7 @@ void server_session::do_read() {
                                 [=]() { write(resp.get_data()); });
 #else
                             write_strand_.post(
-                                [this, resp, z]() { write(resp.get_data()); });
+                                [this, self, resp, z]() { write(resp.get_data()); });
 #endif
                         }
 


### PR DESCRIPTION
This patch fixes the segmentation fault when the client disconnects prematurely causing server_session to be destroyed, while still executing asynchronous tasks.

Tested on: Linux x86_64

Please take note, that I haven't added the self variable to the lambda [here](https://github.com/rpclib/rpclib/blob/master/lib/rpc/detail/server_session.cc#L96), due to the fact that I don't have a Windows PC to test it. The bug probably persists on Windows.