### PR TITLE
Add getter for server port

### DIFF
--- a/include/rpc/dispatcher.h
+++ b/include/rpc/dispatcher.h
@@ -27,6 +27,9 @@ namespace detail {
 //! names, and callable using a msgpack-rpc call pack.
 class dispatcher {
 public:
+    //! \brief Sets the behavior when using non-unique name for functors.
+    void override_functors(bool override);
+
     //! \brief Binds a functor to a name so it becomes callable via RPC.
     //! \param name The name of the functor.
     //! \param func The functor to bind.
@@ -98,7 +101,7 @@ private:
     static void enforce_arg_count(std::string const &func, std::size_t found,
                                   std::size_t expected);
 
-    void enforce_unique_name(std::string const &func);
+    void check_unique_name(std::string const &func);
 
     //! \brief Dispatches a call (which will have a response).
     detail::response dispatch_call(RPCLIB_MSGPACK::object const &msg,
@@ -115,6 +118,7 @@ private:
 private:
     std::unordered_map<std::string, adaptor_type> funcs_;
     RPCLIB_CREATE_LOG_CHANNEL(dispatcher)
+    bool override_functors_ = false;
 };
 }
 }

--- a/include/rpc/dispatcher.inl
+++ b/include/rpc/dispatcher.inl
@@ -3,7 +3,7 @@ namespace rpc {
 namespace detail {
 
 template <typename F> void dispatcher::bind(std::string const &name, F func) {
-    enforce_unique_name(name);
+    check_unique_name(name);
     bind(name, func, typename detail::func_kind_info<F>::result_kind(),
          typename detail::func_kind_info<F>::args_kind());
 }
@@ -12,7 +12,7 @@ template <typename F>
 void dispatcher::bind(std::string const &name, F func,
                       detail::tags::void_result const &,
                       detail::tags::zero_arg const &) {
-    enforce_unique_name(name);
+    check_unique_name(name);
     funcs_.insert(
         std::make_pair(name, [func, name](RPCLIB_MSGPACK::object const &args) {
             enforce_arg_count(name, 0, args.via.array.size);
@@ -28,7 +28,7 @@ void dispatcher::bind(std::string const &name, F func,
     using detail::func_traits;
     using args_type = typename func_traits<F>::args_type;
 
-    enforce_unique_name(name);
+    check_unique_name(name);
     funcs_.insert(
         std::make_pair(name, [func, name](RPCLIB_MSGPACK::object const &args) {
             constexpr int args_count = std::tuple_size<args_type>::value;
@@ -46,7 +46,7 @@ void dispatcher::bind(std::string const &name, F func,
                       detail::tags::zero_arg const &) {
     using detail::func_traits;
 
-    enforce_unique_name(name);
+    check_unique_name(name);
     funcs_.insert(std::make_pair(name, [func,
                                         name](RPCLIB_MSGPACK::object const &args) {
         enforce_arg_count(name, 0, args.via.array.size);
@@ -63,7 +63,7 @@ void dispatcher::bind(std::string const &name, F func,
     using detail::func_traits;
     using args_type = typename func_traits<F>::args_type;
 
-    enforce_unique_name(name);
+    check_unique_name(name);
     funcs_.insert(std::make_pair(name, [func,
                                         name](RPCLIB_MSGPACK::object const &args) {
         constexpr int args_count = std::tuple_size<args_type>::value;

--- a/include/rpc/server.h
+++ b/include/rpc/server.h
@@ -105,6 +105,12 @@ public:
     //! \note Setting this flag only affects subsequent connections.
     void suppress_exceptions(bool suppress);
 
+    //! \brief Sets the behavior when using non-unique functor names in `bind`.
+    //! By default, bind will throw. If overriding is on, old functor will be
+    //! removed and replaced with new one.
+    //! \note Setting this flag only affects subsequent functor bindings.
+    void override_functors(bool override);
+
     //! \brief Stops the server.
     //! \note This should not be called from worker threads.
     void stop();

--- a/include/rpc/server.h
+++ b/include/rpc/server.h
@@ -79,6 +79,11 @@ public:
     //! \param worker_threads The number of worker threads to start.
     void async_run(std::size_t worker_threads = 1);
 
+    //! \brief Returns the port number this server is listening on.
+    //! \note This is especially useful if server is started with an arbitrary
+    //! port number (using port 0 in constructors).
+    uint16_t get_port() const;
+
     //! \brief Binds a functor to a name so it becomes callable via RPC.
     //!
     //! This function template accepts a wide range of callables. The arguments

--- a/lib/rpc/dispatcher.cc
+++ b/lib/rpc/dispatcher.cc
@@ -8,6 +8,10 @@ namespace detail {
 
 using detail::response;
 
+void dispatcher::override_functors(bool override) {
+    override_functors_ = override;
+}
+
 void dispatcher::dispatch(RPCLIB_MSGPACK::sbuffer const &msg) {
     auto unpacked = RPCLIB_MSGPACK::unpack(msg.data(), msg.size());
     dispatch(unpacked.get());
@@ -130,9 +134,10 @@ void dispatcher::enforce_arg_count(std::string const &func, std::size_t found,
     }
 }
 
-void dispatcher::enforce_unique_name(std::string const &func) {
+void dispatcher::check_unique_name(std::string const &func) {
     auto pos = funcs_.find(func);
     if (pos != end(funcs_)) {
+        override_functors_ ? funcs_.erase(pos) :
         throw std::logic_error(
             RPCLIB_FMT::format("Function name already bound: '{}'. "
                                "Please use unique function names", func));

--- a/lib/rpc/server.cc
+++ b/lib/rpc/server.cc
@@ -124,6 +124,10 @@ void server::async_run(std::size_t worker_threads) {
     });
 }
 
+uint16_t server::get_port() const {
+    return pimpl->acceptor_.local_endpoint().port();
+}
+
 void server::stop() { pimpl->stop(); }
 
 void server::close_sessions() { pimpl->close_sessions(); }

--- a/lib/rpc/server.cc
+++ b/lib/rpc/server.cc
@@ -113,6 +113,10 @@ void server::suppress_exceptions(bool suppress) {
     pimpl->suppress_exceptions_ = suppress;
 }
 
+void server::override_functors(bool override) {
+    disp_->override_functors(override);
+}
+
 void server::run() { pimpl->io_.run(); }
 
 void server::async_run(std::size_t worker_threads) {


### PR DESCRIPTION
Let's add a getter for the port the server is listening on. boost:asio allows to create a tcp endpoint using an arbitrary port number (use port number 0). We might obtain this arbitrary port number at a later point.