### PR TITLE
Fixes #190. Race condition when reading on rpc

### DIFF
--- a/lib/rpc/client.cc
+++ b/lib/rpc/client.cc
@@ -192,8 +192,7 @@ void client::wait_conn() {
 }
 
 int client::get_next_call_idx() {
-    ++(pimpl->call_idx_);
-    return pimpl->call_idx_;
+    return ++(pimpl->call_idx_);
 }
 
 void client::post(std::shared_ptr<RPCLIB_MSGPACK::sbuffer> buffer, int idx,


### PR DESCRIPTION
Whenever multiple rpc clients are active within different threads, the are issues while reading content from the rpc client interface.
Like described in the comments in issue #190 this fix solves the race condition.