### PR TITLE
Fix Cookbook "Storing per-session data" lambda

### DIFF
--- a/doc/pages/cookbook.md
+++ b/doc/pages/cookbook.md
@@ -281,7 +281,7 @@ int main() {
     rpc::server srv(8080); // listen on TCP port 8080
     std::unordered_map<rpc::session_id_t, std::string> data;
 
-    srv.bind("store_me_maybe", [](std::string const& value) {
+    srv.bind("store_me_maybe", [&](std::string const& value) {
         auto id = rpc::this_session().id();
         data[id] = value;
     });


### PR DESCRIPTION
Fixed `Storing per-session data` section to have a capturing lambda so the example will work 😄