### PR TITLE
Fix a bug with gcc 4.x

### DIFF
--- a/doc/pages/versions.md
+++ b/doc/pages/versions.md
@@ -1,4 +1,4 @@
-You are reading the documentation of 2.2.0. 
+You are reading the documentation of 2.2.1. 
 If, for some reason you need the documentation of older versions, you can download them from this page.
 
   * [1.0.0](/archive/rpclib_docs_1.0.0.zip)

--- a/include/rpc/detail/log.h
+++ b/include/rpc/detail/log.h
@@ -83,9 +83,12 @@ private:
         std::stringstream ss;
         timespec now_t = {};
         clock_gettime(CLOCK_REALTIME, &now_t);
-        ss << std::put_time(
-                  std::localtime(reinterpret_cast<time_t *>(&now_t.tv_sec)),
-                  "%F %T")
+        char time_string[20];
+        std::strftime(time_string, sizeof(time_string), "%F %T", std::localtime(reinterpret_cast<time_t *>(&now_t.tv_sec)));
+        ss << time_string
+//        ss << std::put_time(
+//                  std::localtime(reinterpret_cast<time_t *>(&now_t.tv_sec)),
+//                  "%F %T")
            << RPCLIB_FMT::format(
                   ".{:03}", round(static_cast<double>(now_t.tv_nsec) / 1.0e6));
         return ss.str();

--- a/include/rpc/version.h
+++ b/include/rpc/version.h
@@ -7,7 +7,7 @@ namespace rpc {
 
 static constexpr unsigned VERSION_MAJOR = 2;
 static constexpr unsigned VERSION_MINOR = 2;
-static constexpr unsigned VERSION_PATCH = 0;
+static constexpr unsigned VERSION_PATCH = 1;
 
 } /* rpc */
 


### PR DESCRIPTION
There is no `std::put_time` in gcc 4.x.
So I replaced it with `std::strftime`.