### PR TITLE
Resolve multithread crash (#175)

### DIFF
--- a/lib/rpc/detail/server_session.cc
+++ b/lib/rpc/detail/server_session.cc
@@ -139,9 +139,6 @@ void server_session::do_read() {
                 LOG_ERROR("Unhandled error code: {} | '{}'", ec, ec.message());
             }
         }));
-    if (exit_) {
-        socket_.close();
-    }
 }
 
 } /* detail */

--- a/lib/rpc/detail/server_session.cc
+++ b/lib/rpc/detail/server_session.cc
@@ -34,9 +34,11 @@ void server_session::start() { do_read(); }
 void server_session::close() {
     LOG_INFO("Closing session.");
     exit_ = true;
-    write_strand_.post([this]() {
+    auto self(shared_from_base<server_session>());
+
+    write_strand_.post([this, self]() {
         socket_.close();
-        parent_->close_session(shared_from_base<server_session>());
+        parent_->close_session(self);
     });
 }
 


### PR DESCRIPTION
Hi, the main goal of this PR is to solve issue #175. Here is the description of what each commit does:

a0e6123 : Add a unit test reproducting issue #175
b18569a : fix thread safety in session management 
8a98779 : Prevent the server_session to be destroyed while its closing code is still queued, causing a segfault
b134678 : Fixed socket double close. If (exit_) is true, then the session is already closed and the socket_.close() is queued

We use your library actively, please give me a feedback on this PR so it could be accepted in the official repository. It would be beneficial for everyone to avoid another fork.