### PR TITLE
Detect failed connect, fix CV spurious wakeup

### DIFF
--- a/include/rpc/nonstd/optional.hpp
+++ b/include/rpc/nonstd/optional.hpp
@@ -564,7 +564,7 @@ class bad_optional_access : public std::logic_error
 public:
   explicit bad_optional_access()
   : logic_error( "bad optional access" ) {}
-  ~bad_optional_access();
+  const char* what() const noexcept;
 };
 
 /// optional

--- a/include/rpc/rpc_error.h
+++ b/include/rpc/rpc_error.h
@@ -54,6 +54,7 @@ private:
 class system_error : public std::system_error {
 public:
     using std::system_error::system_error;
+    const char* what() const noexcept;
 };
 
 } /* rpc */

--- a/include/rpc/rpc_error.h
+++ b/include/rpc/rpc_error.h
@@ -49,6 +49,13 @@ private:
     std::string formatted;
 };
 
+//! \brief This exception is throw by the client when the connection or call
+//! causes a system error
+class system_error : public std::system_error {
+public:
+    using std::system_error::system_error;
+};
+
 } /* rpc */
 
 

--- a/lib/rpc/nonstd/optional.cc
+++ b/lib/rpc/nonstd/optional.cc
@@ -3,4 +3,6 @@
 // This is no-op; the reason it exists is to avoid
 // the weak vtables problem. For more info, see
 // https://stackoverflow.com/a/23749273/140367
-nonstd::bad_optional_access::~bad_optional_access() {}
+const char* nonstd::bad_optional_access::what() const noexcept {
+    return std::logic_error::what();
+}

--- a/lib/rpc/rpc_error.cc
+++ b/lib/rpc/rpc_error.cc
@@ -21,4 +21,6 @@ timeout::timeout(std::string const &what_arg) : std::runtime_error(what_arg) {
 
 const char *timeout::what() const noexcept { return formatted.data(); }
 
+const char* system_error::what() const noexcept { return std::system_error::what(); }
+
 } /* rpc */

--- a/tests/rpc/client_test.cc
+++ b/tests/rpc/client_test.cc
@@ -106,9 +106,29 @@ TEST_F(client_test, timeout_clear) {
     EXPECT_FALSE(client.get_timeout());
 }
 
+// Only enable this test on linux
+// It seems like the connection error is not detected on windows
+TEST_F(client_test, bad_ip) {
+    rpc::client client("127.0.0.2", test_port);
+    client.set_timeout(1000);
+#ifdef __linux__
+    EXPECT_THROW(client.call("dummy_void_zeroarg"), rpc::system_error);
+    // We expect a connection refused, not a timeout
+#else
+    EXPECT_ANY_THROW(client.call("dummy_void_zeroarg"));
+    // throw is enough for windows
+#endif
+}
+
 TEST(client_test2, timeout_while_connection) {
     rpc::client client("localhost", rpc::constants::DEFAULT_PORT);
     client.set_timeout(50);
+#ifdef __linux__
     // this client never connects, so this tests the timout in wait_conn()
-    EXPECT_THROW(client.call("whatev"), rpc::timeout);
+    // We expect a connection refused, not a timeout
+    EXPECT_THROW(client.call("whatev"), rpc::system_error);
+#else
+    EXPECT_ANY_THROW(client.call("dummy_void_zeroarg"));
+    // throw is enough for windows
+#endif
 }


### PR DESCRIPTION
Hello,

This PR adds detection to the client connect. Before this patch, a failed connection is logged, then ignored, causing a timeout in the best case, an infinite wait in the worst case. With this patch, the call to wait_conn will throw a system error containing the error code encountered during connect.
It also fixes the condition variable in wait_conn, protecting it from spurious wakeups.

This PR somehow mitigates #186 as the call to wait_conn will throw, timeout or not.

NOTE: The call to async_connect does not seem to report an error when connecting to a non existing server on windows (given the results of AppVeyor). This means that the feature added by the PR is working only on linux, but has no effect on windows. Although I have a strong believe that this is related to the ASIO library as some versions of Boost.ASIO contained exactly the same bug.