### PR TITLE
Update included asio to handle glibc strerror_r better

### DIFF
--- a/dependencies/include/asio/impl/error_code.ipp
+++ b/dependencies/include/asio/impl/error_code.ipp
@@ -97,20 +97,18 @@ public:
 #if defined(__sun) || defined(__QNX__) || defined(__SYMBIAN32__)
     using namespace std;
     return strerror(value);
-#elif defined(__MACH__) && defined(__APPLE__) \
-  || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__) \
-  || defined(_AIX) || defined(__hpux) || defined(__osf__) \
-  || defined(__ANDROID__)
-    char buf[256] = "";
-    using namespace std;
-    strerror_r(value, buf, sizeof(buf));
-    return buf;
 #else
     char buf[256] = "";
-    return strerror_r(value, buf, sizeof(buf));
+    using namespace std;
+    return strerror_result(strerror_r(value, buf, sizeof(buf)), buf);
 #endif
 #endif // defined(ASIO_WINDOWS)
   }
+
+private:
+  // Helper function to adapt the result from glibc's variant of strerror_r.
+  static const char* strerror_result(int, const char* s) { return s; }
+  static const char* strerror_result(const char* s, const char*) { return s; }
 };
 
 } // namespace detail


### PR DESCRIPTION
This PR applies changes to the handling of `strerror_r` in asio based on this commit:

https://github.com/chriskohlhoff/asio/commit/443bc17d13eb5e37de780ea6e23157493cf7b3b9

This is necessary to make rpclib compile on systems that use a different standard library implementation than glibc, like Alpine.