### PR TITLE
Use error code instead of exception in socket shutdown

### DIFF
--- a/include/rpc/detail/async_writer.h
+++ b/include/rpc/detail/async_writer.h
@@ -49,14 +49,13 @@ public:
 
                     if (exit_) {
                         LOG_INFO("Closing socket");
-                        try {
-                            socket_.shutdown(
-                                RPCLIB_ASIO::ip::tcp::socket::shutdown_both);
-                        }
-                        catch (std::system_error &e) {
-                            (void)e;
+                        std::error_code e;
+                        socket_.shutdown(
+                            RPCLIB_ASIO::ip::tcp::socket::shutdown_both,
+                            e);
+                        if (e) {
                             LOG_WARN("std::system_error during socket shutdown. "
-                                     "Code: {}. Message: {}", e.code(), e.what());
+                                     "Code: {}. Message: {}", e.value(), e.message());
                         }
                         socket_.close();
                     }


### PR DESCRIPTION
I replaced the socket shutdown method by its non-throwing version (using error code instead of exceptions). The behavior is left unchanged but allows to link rpclib to systems with exceptions disabled.

We needed this change for @carla-simulator but I believe it might be useful for other people.