### PR TITLE
Fix of socket inheriting (Win)

### DIFF
--- a/dependencies/include/asio/detail/impl/socket_ops.ipp
+++ b/dependencies/include/asio/detail/impl/socket_ops.ipp
@@ -1382,6 +1382,8 @@ socket_type socket(int af, int type, int protocol,
   if (s == invalid_socket)
     return s;
 
+  SetHandleInformation((HANDLE)s, HANDLE_FLAG_INHERIT, 0);
+
   if (af == ASIO_OS_DEF(AF_INET6))
   {
     // Try to enable the POSIX default behaviour of having IPV6_V6ONLY set to


### PR DESCRIPTION
This commit closes an issue #259:
If application starts another app and then exits (leaving second app
running), listening socket created in first app is still alive (even
after app exit), but this socket isn't used by anyone and even
prevents to start listening again on the same port.