### PR TITLE
CI: Refactor AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,20 @@
-version: 1.0.{build}
-os: Visual Studio 2015
-clone_folder: C:\projects\rpc
-test: off
+image: Visual Studio 2019
+configuration: Release
 
 branches:
   only:
     - master
     - dev
 
-configuration:
-  - Release
-
-environment:
-  matrix:
-    - CMAKE_PLATFORM: "Visual Studio 14 2015"
-    #- CMAKE_PLATFORM: "Visual Studio 15 2017"
-
-install: true
-
-build_script:
-  - cd c:\projects\rpc
+before_build:
   - git submodule init
   - git submodule update --init --recursive
   - md build
   - cd build
-  - cmake -DRPCLIB_BUILD_TESTS=ON -G "%CMAKE_PLATFORM%" ..
-  - cmake --build . --config %CONFIGURATION%
+  - cmake .. -DRPCLIB_BUILD_TESTS=ON
+  
+build:
+  project: build/rpc.sln
+
+test_script:
   - .\tests\Release\rpc_test.exe


### PR DESCRIPTION
Update and clean-up the AppVeyor configuration:
- Updates to Visual Studio 2019 [image](https://www.appveyor.com/docs/windows-images-software/) (which runs on Windows Server 2019)
- Use `msbuild` with the `build/rpc.sln` project instead of `cmake --build`
- Restructure script into `before_build`, `build` and `test_script` parts
- Clean up unused variables