### PR TITLE
disable SO_REUSEADDR on windows

### DIFF
--- a/lib/rpc/server.cc
+++ b/lib/rpc/server.cc
@@ -32,7 +32,9 @@ struct server::impl {
           suppress_exceptions_(false) {
             auto ep = tcp::endpoint(ip::address::from_string(address), port);
             acceptor_.open(ep.protocol());
+#ifndef _WIN32
             acceptor_.set_option(tcp::acceptor::reuse_address(true));
+#endif // !_WIN32
             acceptor_.bind(ep);
             acceptor_.listen();
           }
@@ -45,7 +47,9 @@ struct server::impl {
           suppress_exceptions_(false) {
             auto ep = tcp::endpoint(tcp::v4(), port);
             acceptor_.open(ep.protocol());
+#ifndef _WIN32
             acceptor_.set_option(tcp::acceptor::reuse_address(true));
+#endif // !_WIN32
             acceptor_.bind(ep);
             acceptor_.listen();            
           }


### PR DESCRIPTION
if the same server port being open on 2 servers, binding will not fail and both servers will appear to be running on the same port yet the last server won't accept any connections nor throw any errors. 
check https://github.com/warmcat/libwebsockets/issues/65 for similar discussion and MSDN https://docs.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse