### PR TITLE
Updated doc generation and used clang-format

### DIFF
--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,7 +1,7 @@
 docs_dir: pages
 site_name: rpclib
 
-pages:
+nav:
   - 'Home': 'index.md'
   - 'Guides':
     - 'Getting started': 'gettingstarted.md'
@@ -23,6 +23,7 @@ markdown_extensions:
   - toc:
       permalink: False
       baselevel: 2
+      toc_depth: 5
   - admonition
   - attr_list
   - codehilite

--- a/doc/pages/reference.md
+++ b/doc/pages/reference.md
@@ -40,7 +40,7 @@ Use this class to connect to msgpack-rpc servers and call their exposed function
 | void | [wait_all_responses](#classrpc_1_1client_1ac37437bc05b70588c079079b957eb15f)()
 
 
-<h4 id="classrpc_1_1client_1aafbcbb90607bb189bf75a2020ee14eb8" class="doxy">rpc::client::client</h4>
+#### rpc::client::client
 ```cpp
  rpc::client::client(std::string const &addr, uint16_t port);
 ```
@@ -56,7 +56,7 @@ Constructs a client.
 When a client is constructed, it initiates a connection asynchronically. This means that it will not block while the connection is established. However, when the first call is performed, it *might* block if the connection was not already established.
 
 
-<h4 id="classrpc_1_1client_1a87e0788aaa7a95dfc0e1b9c15dfe4163" class="doxy">rpc::client::~client</h4>
+#### rpc::client::~client
 ```cpp
  rpc::client::~client();
 ```
@@ -67,7 +67,7 @@ Destructor.
 During destruction, the connection to the server is gracefully closed. This means that any outstanding reads and writes are completed first. 
 
 
-<h4 id="classrpc_1_1client_1aedc166b5a80820be198ef134f522b049" class="doxy">rpc::client::call</h4>
+#### rpc::client::call
 ```cpp
 RPCLIB_MSGPACK::object_handle rpc::client::call(std::string const &func_name, Args... args);
 ```
@@ -86,7 +86,7 @@ Calls a function with the given name and arguments (if any).
 A RPCLIB_MSGPACK::object containing the result of the function (if any). To obtain a typed value, use the msgpack API.
 
 
-<h4 id="classrpc_1_1client_1a2e3702a314c8c0a00bfac652b82d16cc" class="doxy">rpc::client::async_call</h4>
+#### rpc::client::async_call
 ```cpp
 std::future< RPCLIB_MSGPACK::object_handle > rpc::client::async_call(std::string const &func_name, Args... args);
 ```
@@ -108,7 +108,7 @@ A call is performed asynchronously in the context of the client, i.e. this is no
 A std::future, possibly holding a future result (which is a RPCLIB_MSGPACK::object). 
 
 
-<h4 id="classrpc_1_1client_1a5f5ad1d1d0630178a51ae219cd831b44" class="doxy">rpc::client::send</h4>
+#### rpc::client::send
 ```cpp
 void rpc::client::send(std::string const &func_name, Args... args);
 ```
@@ -129,7 +129,7 @@ Notifications are a special kind of calls. They can be used to notify the server
 !!! warn
     This function returns immediately (possibly before the notification is written to the socket).
 
-<h4 id="classrpc_1_1client_1a2c264af4d7169574452b9f968ffde87d" class="doxy">rpc::client::get_timeout</h4>
+#### rpc::client::get_timeout
 ```cpp
 nonstd::optional< int64_t > rpc::client::get_timeout() const;
 ```
@@ -142,7 +142,7 @@ The timeout is applied to synchronous calls. If the timeout expires without rece
 !!! warn
     The timeout has no effect on async calls. For those, the preferred timeout mechanism remains using std::future.
 
-<h4 id="classrpc_1_1client_1af890e3067745861642e2ba1a65bebce6" class="doxy">rpc::client::set_timeout</h4>
+#### rpc::client::set_timeout
 ```cpp
 void rpc::client::set_timeout(int64_t value);
 ```
@@ -150,7 +150,7 @@ void rpc::client::set_timeout(int64_t value);
 Sets the timeout for synchronous calls. For more information, see 
 
 
-<h4 id="classrpc_1_1client_1a89eeffaf87bf0470a65c9c8ca40562bb" class="doxy">rpc::client::clear_timeout</h4>
+#### rpc::client::clear_timeout
 ```cpp
 void rpc::client::clear_timeout();
 ```
@@ -158,7 +158,7 @@ void rpc::client::clear_timeout();
 Clears the timeout for synchronous calls. For more information, see 
 
 
-<h4 id="classrpc_1_1client_1a710037bce0d9b80127a98eb6cd54caf1" class="doxy">rpc::client::get_connection_state</h4>
+#### rpc::client::get_connection_state
 ```cpp
 connection_state rpc::client::get_connection_state() const;
 ```
@@ -166,7 +166,7 @@ connection_state rpc::client::get_connection_state() const;
 Returns the current connection state. 
 
 
-<h4 id="classrpc_1_1client_1ac37437bc05b70588c079079b957eb15f" class="doxy">rpc::client::wait_all_responses</h4>
+#### rpc::client::wait_all_responses
 ```cpp
 void rpc::client::wait_all_responses();
 ```
@@ -194,7 +194,7 @@ This type allows clients to handle arbitrary error objects as the msgpack-rpc sp
 | RPCLIB_MSGPACK::object_handle & | [get_error](#classrpc_1_1rpc__error_1a88ab8f211393ae62813042a797c08663)()
 
 
-<h4 id="classrpc_1_1rpc__error_1ac45388bcde0a436b888c907015df01e2" class="doxy">rpc::rpc_error::get_function_name</h4>
+#### rpc::rpc_error::get_function_name
 ```cpp
 std::string rpc::rpc_error::get_function_name() const;
 ```
@@ -202,7 +202,7 @@ std::string rpc::rpc_error::get_function_name() const;
 Returns the name of the function that was called on the server while the error occurred. 
 
 
-<h4 id="classrpc_1_1rpc__error_1a88ab8f211393ae62813042a797c08663" class="doxy">rpc::rpc_error::get_error</h4>
+#### rpc::rpc_error::get_error
 ```cpp
 RPCLIB_MSGPACK::object_handle & rpc::rpc_error::get_error();
 ```
@@ -239,7 +239,7 @@ The server maintains a registry of function bindings that it uses to dispatch ca
 | void | [close_sessions](#classrpc_1_1server_1abf6bebbbeea52451aef2126d29240094)()
 
 
-<h4 id="classrpc_1_1server_1ac406b44f73cf2ff17240c0cd926a9c1e" class="doxy">rpc::server::server</h4>
+#### rpc::server::server
 ```cpp
  rpc::server::server(uint16_t port);
 ```
@@ -250,7 +250,7 @@ Constructs a server that listens on the localhost on the specified port.
 `port` The port number to listen on. 
 
 
-<h4 id="classrpc_1_1server_1a744b961d3b151b3449a4e0da37bd471a" class="doxy">rpc::server::server</h4>
+#### rpc::server::server
 ```cpp
  rpc::server::server(server &&other) noexcept;
 ```
@@ -261,7 +261,7 @@ Move constructor. This is implemented by calling the move assignment operator.
 `other` The other instance to move from. 
 
 
-<h4 id="classrpc_1_1server_1ad71ffce076d752e116cefa3672e5d188" class="doxy">rpc::server::server</h4>
+#### rpc::server::server
 ```cpp
  rpc::server::server(std::string const &address, uint16_t port);
 ```
@@ -274,7 +274,7 @@ Constructs a server that listens on the specified address on the specified port.
 `port` The port number to listen on. 
 
 
-<h4 id="classrpc_1_1server_1a20b9197e5ef1a22371e6fbdb7f58b330" class="doxy">rpc::server::~server</h4>
+#### rpc::server::~server
 ```cpp
  rpc::server::~server();
 ```
@@ -285,7 +285,7 @@ Destructor.
 When the server is destroyed, all ongoin sessions are closed gracefully. 
 
 
-<h4 id="classrpc_1_1server_1ac3cf4848fc3969cd26ba5e3bd2dc411b" class="doxy">rpc::server::operator=</h4>
+#### rpc::server::operator=
 ```cpp
 server rpc::server::operator=(server &&other);
 ```
@@ -299,7 +299,7 @@ Move assignment operator.
 The result of the assignment. 
 
 
-<h4 id="classrpc_1_1server_1a981d7e4a08d04d05cbac6770fab0dff8" class="doxy">rpc::server::run</h4>
+#### rpc::server::run
 ```cpp
 void rpc::server::run();
 ```
@@ -310,7 +310,7 @@ Starts the server loop. This is a blocking call.
 First and foremost, running the event loop causes the server to start listening on the specified port. Also, as connections are established and calls are made by clients, the server executes the calls as part of this call. This means that the handlers are executed on the thread that calls `run`. Reads and writes are initiated by this function internally as well. 
 
 
-<h4 id="classrpc_1_1server_1a462e032fa21cad78eeacc27da103a2b7" class="doxy">rpc::server::async_run</h4>
+#### rpc::server::async_run
 ```cpp
 void rpc::server::async_run(std::size_t worker_threads=1);
 ```
@@ -324,7 +324,7 @@ Starts the server loop on one or more threads. This is a non-blocking call.
 This function behaves similarly to `run`, except the event loop is optionally started on different threads. Effectively this sets up a worker thread pool for the server. Handlers will be executed on one of the threads.
 
 
-<h4 id="classrpc_1_1server_1a072135629430df6d5576416806f7b02c" class="doxy">rpc::server::bind</h4>
+#### rpc::server::bind
 ```cpp
 void rpc::server::bind(std::string const &name, F func);
 ```
@@ -343,7 +343,7 @@ Binds a functor to a name so it becomes callable via RPC.
 This function template accepts a wide range of callables. The arguments and return types of these callables should be serializable by msgpack. `bind` effectively generates a suitable, light-weight compile-time wrapper for the functor.
 
 
-<h4 id="classrpc_1_1server_1a95d336322c9c24cf014404a3b4f70df5" class="doxy">rpc::server::suppress_exceptions</h4>
+#### rpc::server::suppress_exceptions
 ```cpp
 void rpc::server::suppress_exceptions(bool suppress);
 ```
@@ -353,7 +353,7 @@ Sets the exception behavior in handlers. By default, handlers throwing will cras
 !!! warn
     Setting this flag only affects subsequent connections. 
 
-<h4 id="classrpc_1_1server_1a7df94a496caf38b3d679113c1f62082b" class="doxy">rpc::server::stop</h4>
+#### rpc::server::stop
 ```cpp
 void rpc::server::stop();
 ```
@@ -363,7 +363,7 @@ Stops the server.
 !!! warn
     This should not be called from worker threads. 
 
-<h4 id="classrpc_1_1server_1abf6bebbbeea52451aef2126d29240094" class="doxy">rpc::server::close_sessions</h4>
+#### rpc::server::close_sessions
 ```cpp
 void rpc::server::close_sessions();
 ```
@@ -394,7 +394,7 @@ Encapsulates information about the currently executing handler. This is the inte
 | void | [clear](#classrpc_1_1this__handler__t_1a0a53e27b4d8d5b542790b218029d26f4)()
 
 
-<h4 id="classrpc_1_1this__handler__t_1a6cfb57fa89c28bd49c6ec82c42c32e87" class="doxy">rpc::this_handler_t::respond_error</h4>
+#### rpc::this_handler_t::respond_error
 ```cpp
 void rpc::this_handler_t::respond_error(T &&err_obj);
 ```
@@ -408,7 +408,7 @@ Sets an arbitrary object to be sent back as an error response to the client.
 `err_obj` The error object. This can be anything that is possible to encode with messagepack (even custom structures). 
 
 
-<h4 id="classrpc_1_1this__handler__t_1ab825539a615b55772ebc1513cf2b44c7" class="doxy">rpc::this_handler_t::respond</h4>
+#### rpc::this_handler_t::respond
 ```cpp
 void rpc::this_handler_t::respond(T &&resp_obj);
 ```
@@ -424,7 +424,7 @@ Sets an arbitrary object to be sent back as the response to the call.
 !!! warn
     The normal return value of the function (if any) will be ignored if a special response is set. 
 
-<h4 id="classrpc_1_1this__handler__t_1a179997ea536a93f1b8054e0a480876a5" class="doxy">rpc::this_handler_t::disable_response</h4>
+#### rpc::this_handler_t::disable_response
 ```cpp
 void rpc::this_handler_t::disable_response();
 ```
@@ -434,7 +434,7 @@ Instructs the server to not send a response to the client (ignoring any errors a
 !!! warn
     It is unusual to not send a response to requests, and doing so might cause problems in the client (depending on its implementation). 
 
-<h4 id="classrpc_1_1this__handler__t_1aac9c17130dea7ded4bf020a370a0b9aa" class="doxy">rpc::this_handler_t::enable_response</h4>
+#### rpc::this_handler_t::enable_response
 ```cpp
 void rpc::this_handler_t::enable_response();
 ```
@@ -442,7 +442,7 @@ void rpc::this_handler_t::enable_response();
 Enables sending a response to the call. Sending the response is by default enabled. Enabling the response multiple times have no effect. 
 
 
-<h4 id="classrpc_1_1this__handler__t_1a0a53e27b4d8d5b542790b218029d26f4" class="doxy">rpc::this_handler_t::clear</h4>
+#### rpc::this_handler_t::clear
 ```cpp
 void rpc::this_handler_t::clear();
 ```
@@ -470,7 +470,7 @@ Allows controlling the server instance from the currently executing handler.
 | void | [cancel_stop](#classrpc_1_1this__server__t_1a127035c6f2281a5a1bfadf19f4dfe451)()
 
 
-<h4 id="classrpc_1_1this__server__t_1a7e522ccc489d7376e2d795f030f3890f" class="doxy">rpc::this_server_t::stop</h4>
+#### rpc::this_server_t::stop
 ```cpp
 void rpc::this_server_t::stop();
 ```
@@ -478,7 +478,7 @@ void rpc::this_server_t::stop();
 Gracefully stops the server. 
 
 
-<h4 id="classrpc_1_1this__server__t_1a127035c6f2281a5a1bfadf19f4dfe451" class="doxy">rpc::this_server_t::cancel_stop</h4>
+#### rpc::this_server_t::cancel_stop
 ```cpp
 void rpc::this_server_t::cancel_stop();
 ```
@@ -506,7 +506,7 @@ Encapsulates information about the server session/connection this handler is run
 | session_id_t | [id](#classrpc_1_1this__session__t_1aada2250ec9dd3d88781ca16eb4352047)() const
 
 
-<h4 id="classrpc_1_1this__session__t_1ae0551bc44674bdd43e33a4d4a36781b0" class="doxy">rpc::this_session_t::post_exit</h4>
+#### rpc::this_session_t::post_exit
 ```cpp
 void rpc::this_session_t::post_exit();
 ```
@@ -516,7 +516,7 @@ Gracefully exits the session (i.e. ongoing writes and reads are completed; queue
 !!! warn
     Use this function if you need to close the connection from a handler. 
 
-<h4 id="classrpc_1_1this__session__t_1aada2250ec9dd3d88781ca16eb4352047" class="doxy">rpc::this_session_t::id</h4>
+#### rpc::this_session_t::id
 ```cpp
 session_id_t rpc::this_session_t::id() const;
 ```
@@ -545,7 +545,7 @@ This exception is thrown by the client when either the connection or a call take
 | const char * | [what](#classrpc_1_1timeout_1ad782f083798c650188b5927a226c3b04)() const noexcept override
 
 
-<h4 id="classrpc_1_1timeout_1ad782f083798c650188b5927a226c3b04" class="doxy">rpc::timeout::what</h4>
+#### rpc::timeout::what
 ```cpp
 const char * rpc::timeout::what() const noexcept override;
 ```

--- a/doc/reference.md.mako
+++ b/doc/reference.md.mako
@@ -41,7 +41,7 @@ ${"### Public functions"}
 
 
     % for f in c.functions:
-<h4 id="${f.id}" class="doxy">${c.name}::${f.name}</h4>
+${"#### "}${c.name}::${f.name}
 ```cpp
 ${opt(f.type)} ${c.name}::${f.name}${f.argsstr};
 ```

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,22 @@
 lxml>=3.6.4
 Mako>=1.0.4
-mkdocs
+mkdocs>=1.0.0
 pygments
+xsltproc
+docker
+
+
+# Manage Docker as non-root user
+https://docs.docker.com/engine/install/linux-postinstall/
+
+$ sudo groupadd docker
+$ sudo usermod -aG docker $USER
+
+# log out and in to reevaluate user groups or
+$ newgrp docker
+
+# Verify that you can run docker commands without sudo.
+$ docker run hello-world
+
+# If mkdocs serve is used, this is required as well
+mkdocs-material

--- a/lib/rpc/client.cc
+++ b/lib/rpc/client.cc
@@ -23,7 +23,8 @@ using namespace rpc::detail;
 
 namespace rpc {
 
-static constexpr uint32_t default_buffer_size = rpc::constants::DEFAULT_BUFFER_SIZE;
+static constexpr uint32_t default_buffer_size =
+    rpc::constants::DEFAULT_BUFFER_SIZE;
 
 struct client::impl {
     impl(client *parent, std::string const &addr, uint16_t port)
@@ -133,17 +134,11 @@ struct client::impl {
         writer_->write(std::move(item));
     }
 
-    nonstd::optional<int64_t> get_timeout() {
-        return timeout_;
-    }
+    nonstd::optional<int64_t> get_timeout() { return timeout_; }
 
-    void set_timeout(int64_t value) {
-        timeout_ = value;
-    }
+    void set_timeout(int64_t value) { timeout_ = value; }
 
-    void clear_timeout() {
-        timeout_ = nonstd::nullopt;
-    }
+    void clear_timeout() { timeout_ = nonstd::nullopt; }
 
     using call_t =
         std::pair<std::string, std::promise<RPCLIB_MSGPACK::object_handle>>;
@@ -202,9 +197,7 @@ void client::wait_conn() {
     }
 }
 
-int client::get_next_call_idx() {
-    return ++(pimpl->call_idx_);
-}
+int client::get_next_call_idx() { return ++(pimpl->call_idx_); }
 
 void client::post(std::shared_ptr<RPCLIB_MSGPACK::sbuffer> buffer, int idx,
                   std::string const &func_name,
@@ -231,13 +224,9 @@ nonstd::optional<int64_t> client::get_timeout() const {
     return pimpl->get_timeout();
 }
 
-void client::set_timeout(int64_t value) {
-    pimpl->set_timeout(value);
-}
+void client::set_timeout(int64_t value) { pimpl->set_timeout(value); }
 
-void client::clear_timeout() {
-    pimpl->clear_timeout();
-}
+void client::clear_timeout() { pimpl->clear_timeout(); }
 
 void client::wait_all_responses() {
     for (auto &c : pimpl->ongoing_calls_) {
@@ -245,7 +234,7 @@ void client::wait_all_responses() {
     }
 }
 
-RPCLIB_NORETURN void client::throw_timeout(std::string const& func_name) {
+RPCLIB_NORETURN void client::throw_timeout(std::string const &func_name) {
     throw rpc::timeout(
         RPCLIB_FMT::format("Timeout of {}ms while calling RPC function '{}'",
                            *get_timeout(), func_name));
@@ -256,4 +245,4 @@ client::~client() {
     pimpl->io_thread_.join();
 }
 
-}
+} // namespace rpc

--- a/lib/rpc/server.cc
+++ b/lib/rpc/server.cc
@@ -9,17 +9,15 @@
 #include "asio.hpp"
 #include "format.h"
 
-#include "rpc/this_server.h"
 #include "rpc/detail/dev_utils.h"
-#include "rpc/detail/log.h"
 #include "rpc/detail/log.h"
 #include "rpc/detail/server_session.h"
 #include "rpc/detail/thread_group.h"
+#include "rpc/this_server.h"
 
 using namespace rpc::detail;
 using RPCLIB_ASIO::ip::tcp;
 using namespace RPCLIB_ASIO;
-
 
 namespace rpc {
 
@@ -30,14 +28,14 @@ struct server::impl {
           acceptor_(io_),
           socket_(io_),
           suppress_exceptions_(false) {
-            auto ep = tcp::endpoint(ip::address::from_string(address), port);
-            acceptor_.open(ep.protocol());
+        auto ep = tcp::endpoint(ip::address::from_string(address), port);
+        acceptor_.open(ep.protocol());
 #ifndef _WIN32
-            acceptor_.set_option(tcp::acceptor::reuse_address(true));
+        acceptor_.set_option(tcp::acceptor::reuse_address(true));
 #endif // !_WIN32
-            acceptor_.bind(ep);
-            acceptor_.listen();
-          }
+        acceptor_.bind(ep);
+        acceptor_.listen();
+    }
 
     impl(server *parent, uint16_t port)
         : parent_(parent),
@@ -45,14 +43,14 @@ struct server::impl {
           acceptor_(io_),
           socket_(io_),
           suppress_exceptions_(false) {
-            auto ep = tcp::endpoint(tcp::v4(), port);
-            acceptor_.open(ep.protocol());
+        auto ep = tcp::endpoint(tcp::v4(), port);
+        acceptor_.open(ep.protocol());
 #ifndef _WIN32
-            acceptor_.set_option(tcp::acceptor::reuse_address(true));
+        acceptor_.set_option(tcp::acceptor::reuse_address(true));
 #endif // !_WIN32
-            acceptor_.bind(ep);
-            acceptor_.listen();            
-          }
+        acceptor_.bind(ep);
+        acceptor_.listen();
+    }
 
     void start_accept() {
         acceptor_.async_accept(socket_, [this](std::error_code ec) {
@@ -93,9 +91,7 @@ struct server::impl {
         loop_workers_.join_all();
     }
 
-    unsigned short port() const {
-        return acceptor_.local_endpoint().port();        
-    }
+    unsigned short port() const { return acceptor_.local_endpoint().port(); }
 
     server *parent_;
     io_service io_;
@@ -111,18 +107,17 @@ struct server::impl {
 RPCLIB_CREATE_LOG_CHANNEL(server)
 
 server::server(uint16_t port)
-    : pimpl(new server::impl(this, port)), disp_(std::make_shared<dispatcher>()) {
+    : pimpl(new server::impl(this, port)),
+      disp_(std::make_shared<dispatcher>()) {
     LOG_INFO("Created server on localhost:{}", port);
     pimpl->start_accept();
 }
 
-server::server(server&& other) noexcept {
-    *this = std::move(other);
-}
+server::server(server &&other) noexcept { *this = std::move(other); }
 
 server::server(std::string const &address, uint16_t port)
     : pimpl(new server::impl(this, address, port)),
-    disp_(std::make_shared<dispatcher>()) {
+      disp_(std::make_shared<dispatcher>()) {
     LOG_INFO("Created server on address {}:{}", address, port);
     pimpl->start_accept();
 }
@@ -133,7 +128,7 @@ server::~server() {
     }
 }
 
-server& server::operator=(server &&other) {
+server &server::operator=(server &&other) {
     if (this != &other) {
         pimpl = std::move(other.pimpl);
         other.pimpl = nullptr;
@@ -165,15 +160,15 @@ unsigned short server::port() const { return pimpl->port(); }
 void server::close_sessions() { pimpl->close_sessions(); }
 
 void server::close_session(std::shared_ptr<detail::server_session> const &s) {
-  std::unique_lock<std::mutex> lock(pimpl->sessions_mutex_);
-  auto it = std::find(begin(pimpl->sessions_), end(pimpl->sessions_), s);
-  std::shared_ptr<server_session> session;
-  if (it != end(pimpl->sessions_)) {
-    session = *it;
-    pimpl->sessions_.erase(it);
-  }
-  lock.unlock();
-  // session shared pointer is released outside of the mutex
+    std::unique_lock<std::mutex> lock(pimpl->sessions_mutex_);
+    auto it = std::find(begin(pimpl->sessions_), end(pimpl->sessions_), s);
+    std::shared_ptr<server_session> session;
+    if (it != end(pimpl->sessions_)) {
+        session = *it;
+        pimpl->sessions_.erase(it);
+    }
+    lock.unlock();
+    // session shared pointer is released outside of the mutex
 }
 
-} /* rpc */
+} // namespace rpc


### PR DESCRIPTION
Hi there,

I discovered a bug in the reference that the functions are not listed in the toc.
![image](https://user-images.githubusercontent.com/18738222/127619740-85056e07-07ea-41d8-83c7-26e17a986dba.png)

So i decided to change the creation of the reference page.

I also used clang-format with the given .clang-format on client.cc and server.cc.
I did this as a preparation, because i want to add a debug message to the server as asked for in Issue #267.

Have a nice Day,
Marcel Röll

